### PR TITLE
[SP-192] feat: 아이디 중복 검사 API 연동

### DIFF
--- a/src/api/signup.ts
+++ b/src/api/signup.ts
@@ -1,0 +1,10 @@
+import { unauthenticated } from './axiosInstance';
+
+export const fetchUserNameCheck = async (input: string) => {
+  const response = await unauthenticated
+    .post('/api/v1/members/username/check', input)
+    .then(() => true)
+    .catch((error) => error.response.data.message);
+
+  return response;
+};

--- a/src/pages/SignUp/SignUpIdPassword.tsx
+++ b/src/pages/SignUp/SignUpIdPassword.tsx
@@ -3,6 +3,7 @@ import { Input } from 'components/Input';
 import { useForm } from 'react-hook-form';
 import { validIdCheck, validPasswordCheck } from 'validation';
 import { Form } from './style';
+import { fetchUserNameCheck } from 'api/signup';
 
 interface Props {
   handleNextClick(): void;
@@ -28,7 +29,13 @@ export const SignUpIdPassword = ({ updateUserInfo, handleNextClick }: Props) => 
       <Input
         title="아이디"
         error={errors.userId}
-        {...register('userId', { required: '아이디 입력은 필수 입니다.', validate: { validIdCheck } })}
+        {...register('userId', {
+          required: '아이디 입력은 필수 입니다.',
+          validate: {
+            validIdCheck,
+            fetchUserNameCheck,
+          },
+        })}
       />
       <Input
         type="password"


### PR DESCRIPTION
## Issue

closed #28 
[SP-192](https://soma-cupid.atlassian.net/browse/SP-192)

## 요구사항

- [x] 아이디 중복검사 API 연동

## 결과물

![image](https://github.com/SWM-Cupid/jikting-frontend/assets/55674624/50791af4-af2a-4d35-a82e-8f5d09836246)


[SP-192]: https://soma-cupid.atlassian.net/browse/SP-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ