### PR TITLE
[SP-198] 채팅 목록 페이지 생성

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,0 +1,6 @@
+import { authenticated } from './axiosInstance';
+
+export const fetchChatList = async () => {
+  const response = authenticated.get('/api/v1/chattings/rooms');
+  return response;
+};

--- a/src/hooks/useChatQuery.ts
+++ b/src/hooks/useChatQuery.ts
@@ -1,0 +1,13 @@
+import { fetchChatList } from 'api/chat';
+import { useQuery } from 'react-query';
+
+export const useChatListQuery = () => {
+  return useQuery(['chatlist'], fetchChatList, {
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.log(error);
+    },
+  });
+};

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1,31 +1,50 @@
 import { Header } from 'components/Header';
 import * as S from './style';
 import { NavBar } from 'components/NavBar';
+import { useChatListQuery } from 'hooks/useChatQuery';
+
+interface ITeam {
+  chattingRoomId: number;
+  opposingTeamName: string;
+  lastMessage: string;
+  images: string[];
+}
 
 export const ChatList = () => {
+  const { isSuccess, data } = useChatListQuery();
   const hanldeTeamButtonClick = () => {
     // TODO
   };
 
-  return (
-    <S.ChatWrapper>
-      <Header title="채팅" />
-      {/* <S.TeamButton>
+  if (isSuccess && data) {
+    const chatList = data.data;
+    return (
+      <S.ChatWrapper>
+        <Header title="채팅" />
+        {/* <S.TeamButton>
         <Button size="small" title="팀 이름1" onClick={hanldeTeamButtonClick}></Button>
         <Button size="small" title="팀 이름2" onClick={hanldeTeamButtonClick}></Button>
       </S.TeamButton> */}
-      <S.TeamWrapper onClick={hanldeTeamButtonClick}>
-        <S.ImagesWrapper>
-          <S.Image />
-          <S.Image />
-          <S.Image />
-        </S.ImagesWrapper>
-        <S.FlexColumn>
-          <S.TeamName>상대 팀 이름1</S.TeamName>
-          <S.RecentMessage>최근 메시지</S.RecentMessage>
-        </S.FlexColumn>
-      </S.TeamWrapper>
-      <NavBar defaultActive="chat" />
-    </S.ChatWrapper>
-  );
+        {chatList.map((team: ITeam) => {
+          const { chattingRoomId, opposingTeamName, lastMessage, images } = team;
+          return (
+            <S.TeamWrapper onClick={hanldeTeamButtonClick} key={chattingRoomId}>
+              <S.ImagesWrapper>
+                {images.map((image) => (
+                  <S.Image src={image} key={image} />
+                ))}
+                <S.Image />
+                <S.Image />
+              </S.ImagesWrapper>
+              <S.FlexColumn>
+                <S.TeamName>{opposingTeamName}</S.TeamName>
+                <S.RecentMessage>{lastMessage}</S.RecentMessage>
+              </S.FlexColumn>
+            </S.TeamWrapper>
+          );
+        })}
+        <NavBar defaultActive="chat" />
+      </S.ChatWrapper>
+    );
+  }
 };

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -1,0 +1,31 @@
+import { Header } from 'components/Header';
+import * as S from './style';
+import { NavBar } from 'components/NavBar';
+
+export const ChatList = () => {
+  const hanldeTeamButtonClick = () => {
+    // TODO
+  };
+
+  return (
+    <S.ChatWrapper>
+      <Header title="채팅" />
+      {/* <S.TeamButton>
+        <Button size="small" title="팀 이름1" onClick={hanldeTeamButtonClick}></Button>
+        <Button size="small" title="팀 이름2" onClick={hanldeTeamButtonClick}></Button>
+      </S.TeamButton> */}
+      <S.TeamWrapper onClick={hanldeTeamButtonClick}>
+        <S.ImagesWrapper>
+          <S.Image />
+          <S.Image />
+          <S.Image />
+        </S.ImagesWrapper>
+        <S.FlexColumn>
+          <S.TeamName>상대 팀 이름1</S.TeamName>
+          <S.RecentMessage>최근 메시지</S.RecentMessage>
+        </S.FlexColumn>
+      </S.TeamWrapper>
+      <NavBar defaultActive="chat" />
+    </S.ChatWrapper>
+  );
+};

--- a/src/pages/Chat/style.tsx
+++ b/src/pages/Chat/style.tsx
@@ -1,0 +1,82 @@
+import { styled } from 'styled-components';
+
+export const ChatWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+`;
+
+export const TeamButton = styled.div`
+  display: flex;
+  gap: 1rem;
+`;
+
+export const TeamWrapper = styled.div`
+  display: flex;
+  width: 37rem;
+  height: 8rem;
+  border-radius: 2.4rem;
+  background: #fafafa;
+
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+export const ImagesWrapper = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  padding-left: 2rem;
+`;
+
+export const Image = styled.img`
+  position: relative;
+  width: 4.4rem;
+  height: 4.4rem;
+  border-radius: 3rem;
+  border: 2px solid #fafafa;
+  background: lightgray 50% / cover no-repeat;
+
+  &:nth-child(1) {
+    z-index: 4;
+  }
+
+  &:nth-child(2) {
+    left: -10%;
+    z-index: 3;
+  }
+
+  &:nth-child(3) {
+    left: -20%;
+    z-index: 2;
+  }
+
+  &:nth-child(4) {
+    left: -30%;
+    z-index: 1;
+  }
+`;
+
+export const FlexColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+
+export const TeamName = styled.div`
+  color: #212121;
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 2rem;
+`;
+
+export const RecentMessage = styled.div`
+  color: #999;
+  font-size: 1.2rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.6rem;
+`;

--- a/src/pages/Chat/style.tsx
+++ b/src/pages/Chat/style.tsx
@@ -4,7 +4,7 @@ export const ChatWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 2rem;
+  gap: 0.6rem;
 `;
 
 export const TeamButton = styled.div`
@@ -14,9 +14,10 @@ export const TeamButton = styled.div`
 
 export const TeamWrapper = styled.div`
   display: flex;
-  width: 37rem;
+  justify-content: space-between;
+  width: ${Math.min(innerWidth * 0.095, 76.8 * 0.95)}rem;
   height: 8rem;
-  border-radius: 2.4rem;
+  border-radius: 1.2rem;
   background: #fafafa;
 
   :hover {
@@ -61,6 +62,7 @@ export const Image = styled.img`
 
 export const FlexColumn = styled.div`
   display: flex;
+  flex-grow: 1;
   flex-direction: column;
   justify-content: center;
 `;


### PR DESCRIPTION
## Issue

closed #44 
[SP-198](https://soma-cupid.atlassian.net/browse/SP-198)

## 요구사항
- [ ] 채팅 목록 뷰 생성
- [ ] 채팅 목록 API 연동

## 결과물

<img width="340" alt="image" src="https://github.com/SWM-Cupid/jikting-frontend/assets/55674624/b36f5d13-7263-40b8-b001-5da29aa4adfc">


[SP-198]: https://soma-cupid.atlassian.net/browse/SP-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ