### PR TITLE
[SP-273] 토큰 만료시 처리 동작 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { ChatList } from 'pages/Chat';
 import { EditProfile } from 'pages/EditProfile';
 import { SelectLogin } from 'pages/Login';
 import { NormalLogin } from 'pages/Login/NormalLogin';
+import { Main } from 'pages/Main';
 import { SignUp } from 'pages/SignUp';
 import { TeamList } from 'pages/Team';
 import { useEffect } from 'react';
@@ -25,12 +26,12 @@ const App = () => {
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<SelectLogin />} />
-          <Route path="/main" element={<ChatList />} />
+          <Route path="/main" element={<Main />} />
           <Route path="/normallogin" element={<NormalLogin />} />
           <Route path="/signup" element={<SignUp />} />
           <Route path="/editprofile" element={<EditProfile />} />
-          <Route path="/teamlist" element={<TeamList />} />
-          <Route path="/chatlist" element={<ChatList />} />
+          <Route path="/team" element={<TeamList />} />
+          <Route path="/chat" element={<ChatList />} />
         </Routes>
       </BrowserRouter>
     </AppWrapper>

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { InternalAxiosRequestConfig } from 'axios';
 
 export const authenticated = axios.create({
   baseURL: `${import.meta.env.VITE_BASE_URL}`,
@@ -15,3 +15,40 @@ export const unauthenticated = axios.create({
   },
   withCredentials: true,
 });
+
+const refreshAccessToken = async (originalRequest: InternalAxiosRequestConfig) => {
+  const refreshToken = sessionStorage.getItem('rftk');
+  originalRequest.headers['Authorization-refresh'] = `Bearer ${refreshToken}`;
+  return await axios(originalRequest);
+};
+
+authenticated.interceptors.request.use((config) => {
+  config.headers['Authorization'] = localStorage.getItem('actk');
+  return config;
+});
+
+authenticated.interceptors.response.use(
+  (config) => {
+    return config;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response.data.code === 'C008') {
+      const response = await refreshAccessToken(originalRequest);
+      const newAccessToken = response.headers['authorization'];
+      const newRefreshToken = response.headers['authorization-refresh'];
+      localStorage.setItem('actk', `Bearer ${newAccessToken}`);
+      sessionStorage.setItem('rftk', `Bearer ${newRefreshToken}`);
+      originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+      delete originalRequest.headers['Authorization-refresh'];
+      return axios(originalRequest);
+    }
+
+    if (error.response.data.code === 'C009') {
+      alert('토큰이 모두 만료되었습니다..!');
+      window.location.href = '/';
+    }
+    return Promise.reject(error);
+  },
+);

--- a/src/api/login.ts
+++ b/src/api/login.ts
@@ -9,6 +9,7 @@ export const fetchLogin = async ({ username, password }: Props) => {
   const data = await unauthenticated.post('/members/login', { username, password });
   const accessToken = data.headers['authorization'];
   const refreshToken = data.headers['authorization-refresh'];
-  authenticated.defaults.headers['Authorization'] = `Bearer ${accessToken}`;
+
+  localStorage.setItem('actk', `Bearer ${accessToken}`);
   sessionStorage.setItem('rftk', refreshToken);
 };


### PR DESCRIPTION
## Issue

closed #57 
[SP-273](https://soma-cupid.atlassian.net/browse/SP-273)

## 요구사항

- [ ] 액세스 토큰 만료시 리프레시 토큰으로 재전송
- [ ] 새로 받은 액세스 토큰 저장
- [ ] 리프레시 토큰 만료시 로그인 페이지로 이동

## 변경사항
- 액세스토큰 로컬 스토리지에 저장


[SP-273]: https://soma-cupid.atlassian.net/browse/SP-273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ